### PR TITLE
Remove transient on login

### DIFF
--- a/mu-plugins/rpg-restrict-login.php
+++ b/mu-plugins/rpg-restrict-login.php
@@ -32,8 +32,9 @@ class rpgrestrictlogin{
 			'transient_name'	 => 'rpg_restrict_login_',
         );
 
-		add_filter('authenticate', array( $this, 'check_attempted_login' ), 30, 3);
-        add_action('wp_login_failed', array( $this, 'login_failed' ), 10, 1);
+		add_filter('authenticate', array($this, 'check_attempted_login'), 30, 3);
+		add_action('wp_login_failed', array($this, 'login_failed'), 10, 1);
+		add_action('wp_login', array($this, 'login_success'), 10, 2);
     }
 
 	public function check_attempted_login($user, $username, $password) {
@@ -71,6 +72,12 @@ class rpgrestrictlogin{
 				set_transient($trans_name, $datas, $this->settings['lockout_duration']);
 			}
 		}
+	}
+
+	public function login_success($user_login, $user) {
+		$trans_name = $this->settings['transient_name'].$user->ID;
+		//REMOVE TRANSIENT AS SUCCESSFULLY LOGGED IN
+		delete_transient($trans_name);
 	}
 }
 


### PR DESCRIPTION
Update to logic so that when a successful login is actioned then the transient is deleted as per this line in the epic:

Incorrect attempts are sequential and not time specific. Any successful login attempt 'resets the counter'.