### PR TITLE
Preview link fix

### DIFF
--- a/mu-plugins/rpg-non-auth-preview.php
+++ b/mu-plugins/rpg-non-auth-preview.php
@@ -80,6 +80,13 @@ class rpgnonauthpreview{
 		if ($post_status_obj != null) {
 			if (!$post_status_obj->name == 'draft')
 				return $posts;
+		}else{
+			//NO OBJECT - RETURN A 404
+			global $wp_query;
+  			$wp_query->set_404();
+  			status_header(404);
+  			get_template_part(404); 
+  			exit();
 		}
 
 		if (!$this->rpg_verify_nonce($_GET['rpg_nap_nonce'], 'rpg_nap_nonce-'. $posts[0]->ID)) {


### PR DESCRIPTION
If cannot get a post status object throw a 404 - covers instances where a preview link is being used for a post that is no longer a draft or has not been published yet i.e. it is going through a workflow.