### PR TITLE
Stop multiple workflow submissions

### DIFF
--- a/mu-plugins/rpg-utils.php
+++ b/mu-plugins/rpg-utils.php
@@ -436,6 +436,11 @@ class rpgutils{
 		
 	function amend_quick_links($actions, $post) {
 
+		//ONLY SHOW edit LINK FOR POSTS/PAGES @ draft OR publish
+		if($post->post_status !== 'draft' && $post->post_status !== 'publish'){
+			unset($actions['edit']);
+		}
+
 		if (isset($actions['inline hide-if-no-js'])) {
 			unset($actions['inline hide-if-no-js']);
 		}
@@ -1567,6 +1572,12 @@ switch ($post_status) {
 								}
 							}
 						}
+					}
+
+					//CHECK POST STATUS - IF draft OR publish THEN CAN VIEW THE PAGE AND THEREFORE ABLE TO KICK OFF A WORKFLOW REQUEST
+					$post_status = get_post_status($post->ID);
+					if($post_status !== 'draft' && $post_status !== 'publish'){
+						$canaccess= false;
 					}
                 }
 


### PR DESCRIPTION
Two changes made to stop any pages not at draft or publish status from being edited and therefore submitted again to a workflow...