### PR TITLE
Increase max rows in repeater

### DIFF
--- a/mu-plugins/group_5adeed565d840.json
+++ b/mu-plugins/group_5adeed565d840.json
@@ -48,7 +48,7 @@
                     },
                     "collapsed": "",
                     "min": 1,
-                    "max": 10,
+                    "max": 30,
                     "layout": "row",
                     "button_label": "Add item",
                   "sub_fields": [


### PR DESCRIPTION
As per ticket #1582 max rows increased from 10 to 30.