### PR TITLE
Workflow duplicate assignees

### DIFF
--- a/mu-plugins/rpg-utils.php
+++ b/mu-plugins/rpg-utils.php
@@ -730,7 +730,12 @@ switch ($post_status) {
 					switch(a){
 						case 'save':
 							h.setAttribute('style','display:none;');
-							if(g) g.setAttribute('style','float:right;');
+							if(g) {
+								g.setAttribute('style','float:right;');
+								if(g.classList){
+									g.classList.remove('disabled', 'button-disabled', 'button-primary-disabled');
+								}
+							}
 							break;
 						case 'revise':
 							h.setAttribute('style','display:none;');

--- a/third-party-plugins-forked/oasis-workflow/js/pages/subpages/submit-step.js
+++ b/third-party-plugins-forked/oasis-workflow/js/pages/subpages/submit-step.js
@@ -317,6 +317,7 @@ jQuery( document ).ready( function () {
                }
             }
             add_option_to_select("actors-list-select", users, 'name', 'ID');
+            check_for_dupes('actors-list-select');
          }
       });
    });

--- a/third-party-plugins-forked/oasis-workflow/js/pages/subpages/submit-workflow.js
+++ b/third-party-plugins-forked/oasis-workflow/js/pages/subpages/submit-workflow.js
@@ -245,6 +245,7 @@ jQuery( document ).ready( function () {
                }
             }
             add_option_to_select("actors-list-select", users, 'name', 'ID');
+            check_for_dupes('actors-list-select');
          }
 
          action_setting("step", "after");

--- a/third-party-plugins-forked/oasis-workflow/js/pages/workflow-util.js
+++ b/third-party-plugins-forked/oasis-workflow/js/pages/workflow-util.js
@@ -49,6 +49,17 @@ function add_option_to_select(obj,dt,lbl,vl)
 	}	
 }
 
+function check_for_dupes(a){
+	var optValues =[];
+	jQuery('#' + a +' option').each(function(){
+		if($.inArray(this.value, optValues) >-1){
+			jQuery(this).remove()
+		}else{
+			optValues.push(this.value);
+		}
+	});
+}
+
 function numKeys(obj)
 {
     var count = 0;


### PR DESCRIPTION
Fix for intermittent bug where two AJAX calls are fired off to get the assignees - result is duplicate entries in the assignee element.  Code runs to test for and remove any duplicates.